### PR TITLE
Add primitive implementation of slicing component

### DIFF
--- a/src/SlicerProject/Facet.pde
+++ b/src/SlicerProject/Facet.pde
@@ -1,0 +1,137 @@
+/*
+Facet.pde
+ 
+ This Sketchbook tab holds the definition and implementation of the Facet class.
+ 
+ The Facet class represents a trangulated surface defined by a unit normal and 3
+ verticies ordered by the right-hand-rule that use a 3D cartesian coordinate system. 
+ Essentially, it is a triangle located in 3D space. Multiple facets can be composed
+ together to represent a 3D model.
+ 
+ Authors:
+ Slicing Team
+ Chris Iossa (https://www.github.com/ChrisIossa)
+ Paul Canada
+ */
+
+class Facet {
+
+  private PVector vertex1, vertex2, vertex3, facetNormal;
+
+  //constructor that initalizes the vertices
+  public Facet(PVector vertex1, PVector vertex2, PVector vertex3)
+  {
+    this.vertex1 = vertex1;
+    this.vertex2 = vertex2;
+    this.vertex3 = vertex3;
+    facetNormal = null;
+  }
+  
+  //constructor that initalizes the vertices and facet normal
+  public Facet(PVector vertex1, PVector vertex2, PVector vertex3, PVector facetNormal)
+  {
+    this.vertex1 = vertex1;
+    this.vertex2 = vertex2;
+    this.vertex3 = vertex3;
+    this.facetNormal = facetNormal;
+  }
+
+  public Facet()
+  {
+    vertex1 = null;
+    vertex2 = null;
+    vertex3 = null;
+    facetNormal=null;
+  }
+
+  /*
+    This method will handle setting the verticies of the facet.
+   @param    verticiesInput
+   */
+  public boolean setVertex(int vertexIndex, PVector vertexInput)
+  {
+    if (vertexInput == null)
+    {
+      println("Input verticies cannot be null.");
+      return false;
+    }
+
+    try {
+      switch(vertexIndex)
+      {
+      case 0:
+        vertex1 = vertexInput;
+        break;
+
+      case 1:
+        vertex2 = vertexInput;
+        break;
+
+      case 2:
+        vertex3 = vertexInput;
+        break;
+
+      default:
+        println("Invalid index for vertex.");
+        return false;
+      }
+
+      return true;
+    }
+    catch (NullPointerException e)
+    {
+      println("Input vertex cannot be null.");
+
+      return false;
+    }
+  }
+  
+  //function to set facet normal to value specefied @param facetNormal
+  
+  public boolean setFacetNormal(PVector facetNormal)
+  {
+    try 
+    {
+      this.facetNormal = facetNormal;
+      return true;
+    }
+    catch (NullPointerException e)
+    {
+      println("Cannot set a null PVector to a facetNormal.");
+
+      return false;
+    }
+  }
+  
+  //function takes 3 PVectors, and sets them to the facet's corresponding PVector variables
+  public boolean setVertices(PVector vertex1, PVector vertex2, PVector vertex3)
+  {
+    try 
+    {
+      this.vertex1 = vertex1;
+      this.vertex2 = vertex2;
+      this.vertex3 = vertex3;
+
+      return true;
+    }
+    catch (NullPointerException e)
+    {
+      println("Cannot set a null vertex to facet.");
+
+      return false;
+    }
+  }
+
+  //getter for facetNormal
+  
+  public PVector getFacetNormal()
+  {
+    return facetNormal;
+  }
+  
+  //getter for vertexes
+  public PVector[]  getVerticies()
+  {
+    return new PVector[] { vertex1, vertex2, vertex3 };
+  }
+}

--- a/src/SlicerProject/Layer.pde
+++ b/src/SlicerProject/Layer.pde
@@ -1,0 +1,76 @@
+/*
+Layer.pde
+
+This Sketchbook tab holds the definition and implementation of the Layer class.
+
+The Layer class represents the layers of a sliced 3D model. These layers represent
+ locations where the print head will move over, either while extruding material or
+ travelling to another location. These locations are represented as line segments
+ of type Line.
+ 
+Authors: Slicing Team (Paul Canada)
+*/
+
+public class Layer
+{
+  
+  private float zHeight;
+  private ArrayList<Line> lines = new ArrayList<Line>(); 
+
+
+  /*
+    Constructor for Layer object given an initial z value.
+  */
+  public Layer(float inputZHeight)
+  {
+    zHeight = inputZHeight;
+  }
+  
+  
+  /*
+    Constructor for Layer object given an ArrayList<Line> and initial z value.
+  */
+  public Layer(ArrayList<Line> importLines, float inputZHeight)
+  {
+    setCoordinates(importLines);
+    zHeight = inputZHeight;
+  }
+  
+  
+  /*
+    Constructor for default Layer object with no lines in the ArrayList<Line>, and no z value (0).
+  */
+  public Layer()
+  {
+   zHeight = 0; 
+  }
+  
+  
+  /*
+    This method returns the lines stored in the layer.
+    @return  The ArrayList<Line> of lines in the layer.
+  */
+  public ArrayList<Line> getCoordinates() 
+  {
+    return lines;
+  }
+  
+  
+  /*
+    This method will clear out the current lines ArrayList<Line> and add in a new line object for each line object in newLineList
+    @param  newLineList The ArrayList<Line> to import from
+  */
+  public void setCoordinates(ArrayList<Line> newLineList)
+  {
+    // Clear out old line segments to put in new line segments.
+    lines.clear();
+    
+    // Add in each line segment to the ArrayList<Line>.
+    for (Line newLine : newLineList)
+    {
+     lines.add(new Line(newLine.x1, newLine.y1, newLine.x2, newLine.y2, newLine.isTravel)); // Need the Line class to check this
+    }
+    
+  }
+  
+}

--- a/src/SlicerProject/Line.pde
+++ b/src/SlicerProject/Line.pde
@@ -1,0 +1,28 @@
+/*
+Line.pde
+
+This Sketchbook tab holds the definition and implementation of the Line class.
+
+The Line class represents a movement of the print head of a 3D printer. The movements
+ can either be a travel movement or a extrusion movement. These movements are
+ represented as a 2D line segment made up of two points. Both points are publicly
+ accessible.
+ 
+Authors: Slicing Team (Andrew Figueroa)
+*/
+
+public class Line {
+  public float x1;
+  public float y1;
+  public float x2;
+  public float y2;
+  public boolean isTravel;
+  
+  public Line(float x1, float y1, float x2, float y2, boolean isTravel) {
+    this.x1 = x1;
+    this.y1 = y1;
+    this.x2 = x2;
+    this.y2 = y2;
+    this.isTravel = isTravel;
+  }
+}

--- a/src/SlicerProject/Model.pde
+++ b/src/SlicerProject/Model.pde
@@ -1,0 +1,86 @@
+/*
+Model.pde
+
+This Sketchbook tab holds the definition and implementation of the Model class.
+
+The Model class serves as a central object to hold the 3d model currently being
+ processed. It also contains various methods to manipulate the model, including scaling
+ and rotations. Performing these modifications results in the facets that make up the
+ object being modified, along with properties that hold information about these
+ modifications. Finally, the Model class also provides a method to obtain strings
+ that make up an STL file that represents the current state of the model.
+
+Authors: Slicing Team (Andrew Figueroa)
+*/
+
+public class Model
+{
+  private ArrayList<Facet> facets;
+  private boolean isModified;
+  private PVector scaling;
+  private PVector rotation;
+  private PVector translation;
+  
+  public Model(ArrayList<Facet> facets)
+  {
+    this.facets = facets;
+    isModified = false;
+    scaling = new PVector(0, 0, 0);
+    rotation = new PVector(0, 0, 0);
+    translation = new PVector(0, 0, 0);
+  }
+  
+  public ArrayList<Facet> getFacets()
+  {
+    return facets;
+  }
+  
+  public void setFacets(ArrayList<Facet> newFacets) {
+    facets = newFacets;
+  }
+  
+  public PVector getScale()
+  {
+    return scaling; 
+  }
+  
+  public void setScaling(PVector amount)
+  {
+    //TODO
+    isModified = checkModifications();
+  }
+  
+  public PVector getRoatation()
+  {
+    return rotation; 
+  }
+  
+  public void setRoation(PVector amount)
+  {
+    //TODO
+    isModified = checkModifications();
+  }
+  
+  public PVector getTranslation()
+  {
+    return translation;
+  }
+  
+  public void setTranslation(PVector amount)
+  {
+    translation = amount;
+    isModified = checkModifications();
+  }
+  
+  private boolean pVectorEquals(PVector a, PVector b)
+  {
+    return a.x == b.x && a.y == b.y && a.z == b.z;
+  }
+  
+  private boolean checkModifications()
+  {
+    PVector origin = new PVector(0, 0, 0);
+    return pVectorEquals(scaling, origin) && pVectorEquals(rotation, origin)
+           && (pVectorEquals(translation, origin));
+  }
+}

--- a/src/SlicerProject/STLConverter.pde
+++ b/src/SlicerProject/STLConverter.pde
@@ -1,0 +1,300 @@
+/*
+STLConverter.pde
+ 
+ This Sketchbook tab holds the definition and implementation of the STLConverter class.
+ 
+ The STLConverter class serves as a way to convert ASCII STL files to Binary STL files. 
+ This will, in essence, allow our system to handle the slicing of both ASCII and Binary 
+ STL files. If a file is in ASCII format, it will be converted to Binary. Once this
+ conversion has taken place, the STL file can then be parsed.
+ 
+ The Binary STL file requires certain data elements in certain spots to consider it binary; 
+ in this order:
+ - 80 bytes (usually characters) --> Denotes the header
+ - 4 bytes (unsigned integer)    --> Denotes the number of facets in the STL file
+ - 48 bytes (12 floats)          --> Denotes the x,y,z values of the facet (including normals)
+ - 2 bytes (short)               --> Denotes the attribute byte count (this is usually "0" by convention)
+ 
+ Authors: Slicing Team (Paul Canada)
+ */
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.io.FileNotFoundException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.BufferOverflowException;
+
+
+public class STLConverter
+{ 
+  private String path;
+  private byte[] binarySTL = null;
+  private int byteCount = 0;
+  private ArrayList<String> stringsToConvert = new ArrayList<String>();
+  private boolean outputToFile = false;
+
+  /**
+   * Default constructor for STLConverter class
+   */
+  public STLConverter()
+  {
+    path = null;
+  }
+
+  /**
+   * Constructor for STLConverter class given an initial path to the file.
+   */
+  public STLConverter(String path)
+  {
+    this.path = path;
+  }
+
+  /**
+   * Constructor for STLConverter class given an initial path to the file and the instruction to automate the process or not.
+   */
+  public STLConverter(String path, boolean automate)
+  {
+    this.path = path;
+
+    // If automate is true, convertASCII() will be called when object is instantiated instead
+    // of calling it in main.
+    if (automate)
+    { 
+      convertASCII();
+    }
+  }
+
+
+  /**
+   * This method will handle converting the ASCII floats to binary floats.
+   * Simply call object.convertASCII() to grab all the floats from the
+   * STL file and convert them to their respective byte form; also
+   * adding in extra necessary data such as 80 bytes for the header, 4 bytes
+   * for the number of facets in the file, and 2 bytes for an attribute byte count.
+   * By convention, the attribute byte count is always 0.
+   
+   * @return    The byte array containing the binary STL data.
+   * @see        STLConverer.readInLines()
+   */
+  public byte[] convertASCII()
+  {
+    short attribute = 0;
+    int attributeCount = 0;
+    int facetCount = 0;
+
+    // Read in all floats from ASCII STL file.
+    println("Reading file...");
+    if (readInLines()) {
+      // Return null if the Arraylist<String> is empty, as there is an error.
+      if (stringsToConvert.isEmpty())
+      {
+        return null;
+      }
+
+      facetCount = stringsToConvert.size() / 12;
+
+      // Create the ByteBuffer to store all bytes before assigning to byte[]
+      println("Allocating space in the ByteBuffer...");
+      ByteBuffer buffer = ByteBuffer.allocate(byteCount);
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+      // Fill in 80 bytes for the header. At the moment, just fills in with 40 chars, as a char in this sense is 2 bytes.
+      println("Filling in the header...");
+      for (int i = 0; i < 80; i++)
+      {
+        try 
+        {
+          buffer.put(byte(0));
+        } 
+        catch (BufferOverflowException e)
+        {
+          println("Error writing header bytes to byte buffer.");
+          return null;
+        }
+      }
+
+
+      /**
+       * Fill in 4 bytes for the amount of triangles in the STL file.
+       * This number can be computed by taking the size of the stringsToConvert ArrayList<String> and dividing it by 12
+       * as 1 triangle will consist of 9 floats, not including the normal that consists of 3 floats. 
+       * E.g. STL with 3 facets will yield 36 floats (27 for the vertices, and 9 for the normals). 36 / 12 = 3, which gives us 
+       * the number of facets. 
+       */
+      try
+      {
+        buffer.putInt(facetCount);
+      }
+      catch (BufferOverflowException e)
+      {
+        println("Error writing number of triangles in the STL file to byte buffer.");
+        return null;
+      }
+
+      /* Loop through each float (aka "line") and write it to the
+       * Byte Buffer. For every 12 floats, include a 2-byte attribute
+       * count.
+       */
+      println("Converting floats to bytes...");
+      for (String line : stringsToConvert)
+      {
+
+        try
+        {
+          buffer.putFloat(float(line));
+          attributeCount++;
+
+          // Once count is 12, we have completed a facet and need to add the attribute count.
+          if (attributeCount == 12)
+          {
+            attributeCount = 0;
+            buffer.putShort(attribute);
+          }
+        } 
+        catch (BufferOverflowException e)
+        {
+          println("Error writing float:" + float(line) + " to byte buffer.");
+          return null;
+        }
+      }
+
+      // Add all the bytes from the ByteArrayOutputStream to our byte array, which will
+      // be sent to the STLParser. 
+      println("Moving bytes from ByteBuffer to byte[]...");
+      byte convertedBytes[] = buffer.array();
+
+
+      // Attempt to flush Byte Buffer for later use, if needed.
+      buffer.clear();
+
+      // Write converted binarySTL to file
+      if (outputToFile)
+      {
+        try {
+          
+          String outputDirectory = System.getProperty("user.dir") + "\\binary_" + path;
+          println("Writing converted binary file to " + outputDirectory + "...");
+          
+          // Output directory
+          Files.write(Paths.get(outputDirectory), convertedBytes);
+        }
+        catch (IOException e)
+        {
+          println("Error writing converted file to disk. Change the output directory if having issues.");
+        }
+        catch (InvalidPathException ie)
+        {
+          println("Error writing converted file to directory. Change output directory.");
+        }
+      }
+
+
+      // Assign contents of Byte Buffer to STLConverter's binarySTL byte[]
+      binarySTL = convertedBytes;
+      println("Conversion from ASCII to Binary is complete.");
+      return convertedBytes;
+    } else 
+    {
+
+      println("Error reading in STL file.");
+      return null;
+    }
+  }
+
+
+  /**
+   * This method sets the path of the STLConverter object.
+   * @param    path The path to the STL file.
+   */
+  public void setPath(String path)
+  {
+    this.path = path;
+  }
+
+
+
+  /*
+   * This method checks if the binarySTL attribute is null or not.
+   * @return    True if the binarySTL lbyte array is empty, false otherwise.
+   */
+  public boolean checkIfNullBinary()
+  {
+    return (binarySTL == null);
+  }
+
+
+
+  /**
+   * This method will read in lines from the file whose path is given
+   * in the constructor, or manually set using the setPath(...) method.
+   * A regex pattern will be applied to each line to search for any
+   * float that is in scientific or normal form.
+   * e.g. -2.143e-001 ; 7.1394 ; 0.0
+   *
+   * @return    True denoting if the operation finished successfully, false otherwise.
+   */
+  public boolean readInLines()
+  {
+
+    String[] lines = loadStrings(path);
+    ArrayList<String> newLines = new ArrayList<String>();
+
+    // Byte sizes of variables that will need to be allocated for the ByteBuffer
+    final int floatBytes = 4;
+    final int shortBytes = 2;
+    final int headerBytes = 80;
+    int attributeCounter = 0;
+
+    Pattern p = Pattern.compile("-?[0-9]+\\.[0-9]+[Ee]?[-+]?[0-9]*|-?[0-9]+"); // Matches normal floats, scientific notation floats, or single integers.
+    Matcher m;
+
+    // Preliminary check to make sure lines is not empty
+    if (lines == null || lines.length == 0)
+    {
+      return false;
+    }
+
+    // Reserve 80 bytes for the header, and 4 bytes for the number of facets
+    byteCount = headerBytes + floatBytes;
+
+    println("Converting strings to floats...");
+
+    // Loop through each line and apply the regex matching
+    for (int i = 0; i < lines.length; i++)
+    {
+      m = p.matcher(lines[i]);
+
+      // Add matched content (matcher group()) to the private ArrayList<String>
+      while (m.find())
+      {
+        newLines.add(m.group());
+
+        // Reserve 4 bytes for the float
+        byteCount += floatBytes;
+        attributeCounter++;
+
+        if (attributeCounter == 12)
+        {
+          // Reserve 2 bytes for the attribute count
+          byteCount += shortBytes;
+          attributeCounter = 0;
+        }
+      }
+    }
+
+    // Check to make sure operation was successful and we found matches. If not, return false as it must be an error.
+    if (newLines.size() == 0)
+    {
+      println("Error with reading in lines. Could not find any matches to pattern.");
+      return false;
+    } else 
+    {
+      stringsToConvert = newLines;
+      return true;
+    }
+  }
+}

--- a/src/SlicerProject/STLParser.pde
+++ b/src/SlicerProject/STLParser.pde
@@ -1,0 +1,154 @@
+/*
+STLParser.pde
+
+This Sketchbook tab holds the definition and implementation of the STLParser class.
+
+The STLParser class is responsible for reading in an STL file and interpreting the facets
+ located within the file. The STLParser class automatically determines whether a given STL
+ file is a Binary STL or an ASCII STL.
+ 
+Due to the use of ArrayList to hold Facets, it is not possible to handle STLs that contain
+ more than 2^31 - 1 facets. Parsing STL files that contain tens or hundreds of millions of
+ facets may require increasing the memory allowed to the sketch in the Preferences window.
+ 
+Authors: Slicing Team (Andrew Figueroa)
+*/
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.BufferUnderflowException;
+
+public class STLParser
+{
+  private final String filePath;
+  
+  /**
+   * Constructs an STLParser object given a file path to a .stl file. The path and file
+   * pointed to by the path are not checked for validity until STLParser.parseSTL() is called.
+   * <p>
+   * If the .stl file pointed to can be is an ASCII STL file, the STLParser class first
+   * converts it to a Binary STL using the STLConverter class.
+   *
+   * @param  path  an absolute file path to a Binary or ASCII STL file
+   */
+  public STLParser(String path)
+  {
+    if (path == null)
+    {
+      filePath = "";
+    }
+    else
+    {
+      filePath = path;
+    }
+  }
+  
+  /**
+   * Parses the .stl file at the location given during the construction of the object. Does
+   * not throw any exceptions or return error codes. If an error occurs during parsing, null
+   * is returned. Currently, if an error is detected, debug information may be printed to 
+   * System.out.
+   * <p>
+   * This method can be reused to obtain a clean copy of the facets from the original STL file,
+   * provided that the original .stl file is still accessible. 
+   * 
+   * @return  an ArrayList<Facet> of facets that were represented by the .stl file
+   * @see     STLParser.STLParser()
+   */
+  public ArrayList<Facet> parseSTL()
+  {
+    ArrayList<Facet> facets = null;
+    
+    //read in file from disk, contents is set to null if an error occured
+    byte[] contents = loadBytes(filePath);
+    
+    //convert any ASCII STL to Binary STL
+    if (contents != null && contents.length >= 5)
+    {
+      //detects an ASCII STL by checking if the first 5 bytes match "solid"
+      if (contents[0] == 's' && contents[1] == 'o' && contents[2] == 'l' && contents[3] == 'i'
+          && contents[4] == 'd')
+      {
+        STLConverter converter = new STLConverter(filePath);
+        contents = converter.convertASCII();
+      }
+    }
+    
+    //interpret facets
+    facets = interpretBinarySTL(contents);
+    
+    return facets;
+  }
+
+  /**
+   * Interprets (parses) an array of bytes as a Binary STL file. If the number of facets
+   * reported in the STL file does not match the number of facets interpreted, then null
+   * is returned.
+   *
+   * @param  stlContents  an array of bytes that represents the contents of a Binary STL file
+   * @return              an ArrayList<Facet> of facets that were represented by the contents
+   */
+  private ArrayList<Facet> interpretBinarySTL(byte[] stlContents)
+  {
+    ArrayList<Facet> facets = null;
+    final int STL_HEADER_SIZE = 80; //num of bytes in Binary STL header
+    
+    if (stlContents != null && stlContents.length > STL_HEADER_SIZE)
+    {
+      long facetCount = 0;
+      
+      //set up ByteBuffer to process data, starting after the Binary STL header
+      ByteBuffer buffer = ByteBuffer.wrap(stlContents, STL_HEADER_SIZE,
+                                          stlContents.length - STL_HEADER_SIZE);
+      buffer.order(ByteOrder.LITTLE_ENDIAN); //STL files are little endian by convention
+      
+      //process data within stlContents through ByteBuffer
+      try {
+        //STL files store facet count as UINT32, Java/Processing does not have unsigned types
+        facetCount = Integer.toUnsignedLong(buffer.getInt());
+        println("STLParser.interpretBinarySTL(): STL Facet count: " + facetCount); //TODO: remove after development
+        
+        if (facetCount < Integer.MAX_VALUE) //we cannot handle more than 2^31-1 facets due to ArrayList
+        {
+          facets = new ArrayList<Facet>();
+          facets.ensureCapacity((int)facetCount);
+          
+          while (true) //until exception occurs (BufferUnderflowException expected at end)
+          {
+            PVector normal = new PVector(buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
+            PVector v1 = new PVector(buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
+            PVector v2 = new PVector(buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
+            PVector v3 = new PVector(buffer.getFloat(), buffer.getFloat(), buffer.getFloat());
+            buffer.getShort(); //skip STL "attribute byte count" property
+            
+            facets.add(new Facet(v1, v2, v3, normal));
+          }
+        }
+        else
+        {
+          System.out.println("STLParser.interpretBinarySTL(): Could not parse STL as it contained" +
+                             " over Integer.MAX_VALUE (2^31 - 1) facets");
+        }
+      }
+      catch (BufferUnderflowException ex)
+      {
+        if (facets == null)
+        {
+          System.out.println("STLParser.interpretBinarySTL(): Could not read facet count property" + 
+                             " of stlContents. This may not be a valid STL file");
+        }
+        else if (facetCount != facets.size())
+        {
+          System.out.println("STLParser.interpretBinarySTL(): Facet count property did not match" + 
+                             " number of interpreted facets. This may not be a valid STL file");
+        }
+      }
+    }
+    else
+    {
+      System.out.println("STLParser.interpretBinarySTL(): stlContents was not a valid STL file" + 
+                         " (null or length < 80 bytes).");
+    }
+    return facets;
+  }
+}

--- a/src/SlicerProject/Slicer.pde
+++ b/src/SlicerProject/Slicer.pde
@@ -1,0 +1,339 @@
+/*
+Slicer.pde
+
+This Sketchbook tab holds the definition and implementation of the Slicer class.
+
+The Slicer class represents the controller for the slicing process that converts a 3D
+ model into a series of 2D layers. Methods are provided to turn Facets that make up a
+ 3D model into a list of layers, and to process the layers into RepRap GCode that provides
+ instructions to a 3D printer on how to physically reproduce the 3D model.
+ 
+TODO: Currently, only the most basic slicing has been implemented. Walls, top and bottom
+ layers, travels, and GCode creation have not yet been implemented.
+
+Authors:
+ Andrew Figueroa, Aaron Finnegan (Slicing Team)
+*/
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.Comparator;
+import java.util.HashSet;
+
+public class Slicer
+{
+  private TreeMap<Float, ArrayList<Facet>> lowVSort;
+  private TreeMap<Float, ArrayList<Facet>> highVSort;
+  private final float layerHeight;
+  private final float infillPercentage;
+ 
+  /**
+  * Constructor
+  *
+  * @param  facets  A representation of the facets that make up the 3D model
+  * @param  layerHeight  The desired z-height of each layer in the sliced object. 
+  * Must be > 0.0, otherwise, it is set to 1.5
+  * @param  infill  Percentage of the inside part of the object that should be
+  * filled with material. Should be between 0 and 1
+  */
+  public Slicer(ArrayList<Facet> facets, float layerHeight, float infill)
+  {
+    //validate and set layer height
+    if (layerHeight <= 0.0)
+    {
+      layerHeight = .2;
+    }
+    this.layerHeight = layerHeight;
+    
+    //validate and set infill percentage
+    if (infill > 1.0)
+    {
+      infill = 1.0;
+    }
+    else if (infill < 0.0)
+    {
+      infill = 0;
+    }
+    this.infillPercentage = infill; //TODO: validate
+    
+    //create "psuedo-multimap" sorted low to high by the lowest z-height
+    lowVSort = new TreeMap<Float, ArrayList<Facet>>();
+    for (Facet f: facets)
+    {
+      Float minZ = getLowestZVertex(f).z;
+      ArrayList<Facet> sameMinZ = lowVSort.get(minZ);
+      if (sameMinZ == null)
+      {
+        lowVSort.put(minZ, sameMinZ = new ArrayList<Facet>());
+      }
+      sameMinZ.add(f);
+    }
+    
+    //create "psuedo-multimap" sorted low to high by the highest z-height
+    highVSort = new TreeMap<Float, ArrayList<Facet>>();
+    for (Facet f: facets)
+    {
+      Float maxZ = getHighestZVertex(f).z;
+      ArrayList<Facet> sameMaxZ = highVSort.get(maxZ);
+      if (sameMaxZ == null)
+      {
+        highVSort.put(maxZ, sameMaxZ = new ArrayList<Facet>());
+      }
+      sameMaxZ.add(f);
+    }
+  }
+  
+  
+  /**
+  * Slices the 3D model to a printable representation at intervals that match layerHeight
+  *
+  * This method completely slices the 3D model given at object creation to its printable
+  * representation. This includes determining the intersections of the 3D model, adding
+  * walls, adding infill, and determining necessary travels for each layer.
+  *
+  * @return  An ArrayList<Layer> of the layers that make up the printable representation
+  * of the 3D model.
+  */
+  public ArrayList<Layer> sliceLayers()
+  {
+    float highestPos = highVSort.lastEntry().getKey();
+    
+    ArrayList<Layer> layers = new ArrayList<Layer>();
+    layers.ensureCapacity((int)(highestPos / layerHeight) + 1);
+    
+    for (float pos = 0; pos < highestPos; pos += layerHeight)
+    {
+      //TODO: account for bottom and top layers (these need an infill of 1)
+      
+      Layer currLayer = sliceLayer(pos);
+      //currLayer = addInfill(currLayer, infillPercentage);
+      //TODO: add walls
+      //TODO: compute travels
+      
+      layers.add(currLayer);
+    }
+    
+    return layers;
+  }
+  
+  
+  /**
+  * Gets the RepRap GCode that can be used to print the 3D model
+  *
+  * This method uses the information in layers to create RepRap GCode commands that can
+  * be sent to a compatable 3D printer in order to print the 3D model represented by
+  * the given layers.
+  *
+  * @param  layers  An ArrayList<Layer> of layers to be printed
+  * @return  An ArrayList<String> of RepRap GCode commands ready to be sent to a printer
+  */
+  public ArrayList<String> createGCode(ArrayList<Layer> layers)
+  {
+    ArrayList<String> gCode = null;
+    //TODO: Implement createGCode()
+    return gCode;
+  }
+  
+  
+  /**
+  * Slices the given layer
+  *
+  * This method determines the facets that intersect the plane at the given z-height,
+  * creates lines between the two intersections of each facet, and places them into a 
+  * Layer object which is returned
+  *
+  * @param  ZPos  The height of the layer to slice
+  * @return  A Layer object that represents the 2-dimensional intersections of the model
+  * at the given height.
+  */
+  public Layer sliceLayer(float zPos)
+  {
+    //create sub-maps containg only the facets that intersect the current z-height
+    NavigableMap<Float, ArrayList<Facet>> lowerFacets = lowVSort.headMap(zPos, true);
+    NavigableMap<Float, ArrayList<Facet>> upperFacets = highVSort.tailMap(zPos, true);
+    
+    //get a HashSet<Facet> of the facets that are in both submaps
+    HashSet<Facet> allLowerFacets = extractFacets(lowerFacets.values());
+    HashSet<Facet> allUpperFacets = extractFacets(upperFacets.values());
+    allLowerFacets.retainAll(allUpperFacets);
+    HashSet<Facet> intersectingFacets = allLowerFacets;
+    
+    //TEMP: Debug info
+    println("Slicer.sliceLayer(): Intersecting facets at height " + zPos + ": " +
+            intersectingFacets.size());
+    
+    //create ArrayList to hold lines which represent the intersections at zPos
+    ArrayList<Line> lines = new ArrayList<Line>();
+    lines.ensureCapacity(intersectingFacets.size());
+    
+    //this comparator compares the z value of two PVectors
+    PVectorZComparator compZ = new PVectorZComparator();
+    
+    for (Facet f : intersectingFacets)
+    {
+      /* Except for the case where there is only one point at zPos, the algorithm uses 
+       linear interpolation to calculate the two points where the lines of the facet
+       intersect with the plane at zPos. It then creates a line with these two points
+       as the line's end points. See https://en.wikipedia.org/wiki/Linear_interpolation
+         The linear interpolation is performed using the PVector.lerp() function for
+       simplicity. However, all the function does is: start + (stop-start) * amount
+       for each of the three floats in a PVector. amount is determined by finding the
+       percentage of the facet's line that is "cut off" by the current plane. */
+      
+      int numHigherVerts = numVerteciesAbove(f, zPos);
+      
+      if (numHigherVerts == 0) //single point on current plane, 2 below
+      {
+        PVector p = getHighestZVertex(f);
+        lines.add(new Line(p.x, p.y, p.x, p.y, false));
+      }
+      else if (numHigherVerts == 1) //1 point above, 2 points below or on current plane 
+      {
+        PVector[] sortedVerts = f.getVerticies(); //not sorted until next line
+        Arrays.sort(sortedVerts, compZ);
+        
+        //calculate first point
+        float liFactor1 = (zPos - sortedVerts[0].z) / (sortedVerts[2].z - sortedVerts[0].z); 
+        PVector p1 = PVector.lerp(sortedVerts[0], sortedVerts[2], liFactor1);
+        
+        //calculate second point
+        float liFactor2 = (zPos - sortedVerts[1].z) / (sortedVerts[2].z - sortedVerts[1].z); 
+        PVector p2 = PVector.lerp(sortedVerts[1], sortedVerts[2], liFactor2);
+        
+        //create line
+        lines.add(new Line(p1.x, p1.y, p2.x, p2.y, false));
+      }
+      else //2 points above, 1 point below or on current plane
+      {
+        PVector[] sortedVerts = f.getVerticies(); //not sorted until next line
+        Arrays.sort(sortedVerts, compZ);
+        
+        //calculate first point
+        float liFactor1 = (zPos - sortedVerts[0].z) / (sortedVerts[1].z - sortedVerts[0].z);
+        PVector p1 = PVector.lerp(sortedVerts[0], sortedVerts[1], liFactor1);
+        
+        //calculate second point
+        float liFactor2 = (zPos - sortedVerts[0].z) / (sortedVerts[2].z - sortedVerts[0].z);
+        PVector p2 = PVector.lerp(sortedVerts[0], sortedVerts[2], liFactor2);
+        
+        //create line
+        lines.add(new Line(p1.x, p1.y, p2.x, p2.y, false));
+      }
+    }
+    
+    return new Layer(lines, zPos);
+  }
+  
+  
+  /**
+  * Gets RepRap GCode that prints the given Layer
+  *
+  * This method interpets a single layer object and creates GCode that can be used
+  * to print this layer on a RepRap compatable 3D printer
+  *
+  * @param  layer  The layer to create GCode instructions for
+  * @return  An ArrayList<String> of GCode commands that will print the given layer
+  */
+  private ArrayList<String> layerToGCode(Layer l)
+  {
+    ArrayList<String> LayerGCode = null;
+    //TODO: implement layerToGCode()
+    return LayerGCode;
+  }
+  
+  
+  /**
+  * Adds structural infill to the given layer
+  *
+  * This method adds Line objects to the given Layer that represent infill. The
+  * the given layer must represent a closed figure. An infill percentage of 1 will
+  * result in a layer with no hollow portion (useful for bottom and top layers)
+  *
+  * @param  layer  The Layer object to add infill to
+  * @param  infillPercentage  Amount of infill to add to the layer (0 to 1)
+  * @return The layer object with infill added
+  */
+  private Layer addInfill(Layer l)
+  {
+    Layer layerInfill = null;
+    //TODO: implement addInfill()
+    return layerInfill;
+  }
+  
+  
+  /* returns a PVector of the vertex with the lowest z-position */
+  private PVector getLowestZVertex(Facet f)
+  {
+    PVector[] verts = f.getVerticies();
+    PVector lowest = verts[0];
+    if (verts[1].z < lowest.z)
+    {
+      lowest = verts[1];
+    }
+    if (verts[2].z < lowest.z)
+    {
+      lowest = verts[2];
+    }
+    return lowest;
+  }
+  
+  
+  /* returns a PVector of the vertex with the highest z-position */
+  private PVector getHighestZVertex(Facet f)
+  {
+    PVector[] verts = f.getVerticies();
+    PVector highest = verts[0];
+    if (verts[1].z > highest.z)
+    {
+      highest = verts[1];
+    }
+    if (verts[2].z > highest.z)
+    {
+      highest = verts[2];
+    }
+    return highest;
+  }
+  
+  
+  /* returns all of the facets located within a Collection of ArrayLists<Facet>s */
+  private HashSet<Facet> extractFacets(Collection<ArrayList<Facet>> col)
+  {
+    HashSet<Facet> allFacets = new HashSet<Facet>();
+    
+    for (ArrayList<Facet> af : col)
+    {
+      allFacets.addAll(af);
+    }
+    
+    return allFacets;
+  }
+  
+  
+  /* returns the number of vertecies in f that are above a given Z-height*/
+  private int numVerteciesAbove(Facet f, float zPos)
+  {
+    int count = 0;
+    PVector[] verts = f.getVerticies();
+    for (PVector v: verts)
+    {
+      if (v.z > zPos)
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+  
+}
+
+/* Implements a java.util.Comparator to compare the Z-height of two PVectors */
+private class PVectorZComparator implements Comparator<PVector>
+{
+  @Override
+  public int compare(PVector a, PVector b)
+  {
+    return a.z == b.z ? 0 : a.z < b.z ? -1 : 1;
+  }
+}

--- a/src/SlicerProject/SlicerProject.pde
+++ b/src/SlicerProject/SlicerProject.pde
@@ -1,0 +1,25 @@
+/*
+SlicerProject.pde
+
+This Sketchbook tab contains the main code that runs the entire program. 
+
+For more information, view the accompanying READMEs located throughout the project. 
+
+Authors:
+*/
+
+//This function is automatically called when the project is run/executed.
+// Once this function finished executing, the draw function is called (repeatedly).
+void setup() {
+  
+ 
+  
+}
+
+//After the setup function finishes, this function is called repeatedly until the
+// program exits.
+//Depending on how the project proceeds, we may not use this function, and instead
+// treat the setup function as if it were similar to a main function in C/C++/Java.
+void draw() {
+  
+}


### PR DESCRIPTION
This pull request adds an early version of the classes involved in slicing a 3D model. Currently. the 3D model is transformed into a series of layers, but is not yet ready for printing.

The following is yet to be implemented:
- Adding extra perimeters to the model
- Adding infill
- Making top and bottom layers solid
- Forming a tool path (including travels)
- GCode generation

However, all valid STLs are now sliced into their "actual" representation (but not their printable representation)


***

Here is a sample of code that allows the testing of the slicing portion:

You need to set the file path (either absolute or relative), layer height (usually 0.1 - 0.3 depending on desired quality), and layer to draw (depends on the model and what part of the model you wish to view; must be less than the total number of layers in the sliced object)

You're also going to have to play around with the values in the drawing section (inside of the loop) depending on the model you are slicing.

```java
//parse STL
STLParser parser = new STLParser(<FILE_PATH>);
ArrayList<Facet> facets = parser.parseSTL();

//slice object, including timing the slicing procedure
long startTime = millis();
Slicer slice = new Slicer(facets, <LAYER_HEIGHT>, 0);
ArrayList<Layer> layers = slice.sliceLayers();
long endTime = millis();
println("\nTotal time: " + (endTime - startTime) + "ms");
println("Total number of layers: " + layers.size());

//draw sliced object
size(800, 800);
int layerToDraw = <LAYER_TO_DRAW>;
ArrayList<Line> lines = layers.get(layerToDraw).getCoordinates();
for (Line li : lines)
{
  //scale and translate drawn layer (units are in mm and the model is centered around 0)
  li.x1 *= 10;
  li.y1 *= 10;
  li.x2 *= 10;
  li.y2 *= 10;

  li.x1 += 400;
  li.y1 += 400;
  li.x2 += 400;
  li.y2 += 400;

  line(li.x1, li.y1, li.x2, li.y2);
}
println("Num lines on drawn layer (" + layerToDraw + "): " + lines.size());
```